### PR TITLE
460 create activejob migration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,7 @@ group :development do
   gem 'pry'
   gem 'dotenv'
 end
+
+group :test do
+  gem 'webmock'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,6 @@ group :development do
 end
 
 group :test do
+  gem 'rspec-rails'
   gem 'webmock'
 end

--- a/lib/tasks/tessa.rake
+++ b/lib/tasks/tessa.rake
@@ -1,0 +1,7 @@
+
+namespace :tessa do
+  desc "Begins the migration of all Tessa assets to ActiveStorage."
+  task :migrate => :environment do
+    Tessa::MigrateAssetsJob.perform_later
+  end
+end

--- a/lib/tessa.rb
+++ b/lib/tessa.rb
@@ -14,7 +14,10 @@ require "tessa/model"
 require "tessa/rack_upload_proxy"
 require "tessa/upload"
 require "tessa/view_helpers"
-require "tessa/jobs/migrate_assets_job"
+
+if defined?(ActiveJob)
+  require "tessa/jobs/migrate_assets_job"
+end
 
 module Tessa
   class << self

--- a/lib/tessa.rb
+++ b/lib/tessa.rb
@@ -31,6 +31,10 @@ module Tessa
       return find_asset(ids)
     end
 
+    def model_registry
+      @model_registry ||= []
+    end
+
     private
 
     def find_asset(id)

--- a/lib/tessa.rb
+++ b/lib/tessa.rb
@@ -14,6 +14,7 @@ require "tessa/model"
 require "tessa/rack_upload_proxy"
 require "tessa/upload"
 require "tessa/view_helpers"
+require "tessa/jobs/migrate_assets_job"
 
 module Tessa
   class << self

--- a/lib/tessa/active_storage/asset_wrapper.rb
+++ b/lib/tessa/active_storage/asset_wrapper.rb
@@ -20,7 +20,8 @@ module Tessa::ActiveStorage
     def meta
       {
         mime_type: content_type,
-        size: byte_size
+        size: byte_size,
+        name: filename
       }
     end
 

--- a/lib/tessa/jobs/migrate_assets_job.rb
+++ b/lib/tessa/jobs/migrate_assets_job.rb
@@ -34,7 +34,7 @@ class Tessa::MigrateAssetsJob < ActiveJob::Base
       remaining_batches = (processing_state.count / options[:batch_size].to_f).ceil
 
       Rails.logger.info("Continuing processing in #{interval}, "\
-        "ETA #{remaining_batches * interval}. "\
+        "ETA #{(remaining_batches * interval).from_now}. "\
         "Working on #{processing_state.next_model.next_field}")
 
       processing_state.batch_count = 0

--- a/lib/tessa/jobs/migrate_assets_job.rb
+++ b/lib/tessa/jobs/migrate_assets_job.rb
@@ -1,0 +1,49 @@
+class Tessa::MigrateAssetsJob < ActiveJob::Base
+
+  def perform(*args)
+    options = args&.extract_options!
+    options = {
+      batch_size: 10,
+      interval: 10.minutes
+    }.merge!(options&.symbolize_keys || {})
+    klasses = args.presence ||
+      load_models_from_registry
+
+    count = 0
+    while klasses.any?
+      count += process(klasses.first, batch_size: options[:batch_size] - count)
+      if count >= options[:batch_size]
+        klasses.shift
+        self.class.perform_later(*klasses, **options)
+      end
+    end
+  end
+
+  private
+
+  def process(klass, batch_size:)
+    count = 0
+    klass.tessa_fields.each do |name, field|
+      # Find all records where id field is not nil, limit by batch size
+      records = klass
+        .where.not(Hash[field.id_field, nil])
+        .limit(batch_size)
+        .to_a
+
+      records.each { |r| reupload(r, field) }
+      count += records.length
+      break if count >= batch_size
+    end
+
+    count
+  end
+
+  def reupload(record, field)
+    # TODO
+  end
+
+  def load_models_from_registry
+    Rails.application.eager_load!
+    Tessa.model_registry
+  end
+end

--- a/lib/tessa/jobs/migrate_assets_job.rb
+++ b/lib/tessa/jobs/migrate_assets_job.rb
@@ -6,44 +6,146 @@ class Tessa::MigrateAssetsJob < ActiveJob::Base
       batch_size: 10,
       interval: 10.minutes
     }.merge!(options&.symbolize_keys || {})
-    klasses = args.presence ||
+    processing_state = args.first ||
       load_models_from_registry
 
-    count = 0
-    while klasses.any?
-      count += process(klasses.first, batch_size: options[:batch_size] - count)
-      if count >= options[:batch_size]
-        klasses.shift
-        self.class.perform_later(*klasses, **options)
-      end
+    processing_state.batch_count = 0
+    while processing_state.batch_count < options[:batch_size]
+      model_state = processing_state.next_model
+
+      process(processing_state, model_state, options)
+
+      break if processing_state.fully_processed?
+    end
+
+    unless processing_state.fully_processed?
+      self.class.perform_later(processing_state, options)
     end
   end
 
   private
 
-  def process(klass, batch_size:)
-    count = 0
-    klass.tessa_fields.each do |name, field|
-      # Find all records where id field is not nil, limit by batch size
-      records = klass
-        .where.not(Hash[field.id_field, nil])
-        .limit(batch_size)
-        .to_a
+  def process(processing_state, model_state, options)
+    while processing_state.batch_count < options[:batch_size]
+      field_state = model_state.next_field
 
-      records.each { |r| reupload(r, field) }
-      count += records.length
-      break if count >= batch_size
+      process_field(processing_state, field_state, options)
+
+      return if model_state.fully_processed?
     end
-
-    count
   end
 
-  def reupload(record, field)
+  def process_field(processing_state, field_state, options)
+    while processing_state.batch_count < options[:batch_size]
+      remaining = options[:batch_size] - processing_state.batch_count
+
+      next_batch = field_state.query
+        .offset(field_state.offset)
+        .limit(remaining)
+
+      next_batch.each do |record|
+        begin
+          reupload(record, field_state)
+
+        rescue StandardError => ex
+          Rails.logger.error("Error reuploading #{record.id}##{field_state.field_name}\n#{ex}")
+          field_state.failed_ids << record.id
+        ensure
+          field_state.offset += 1
+          processing_state.batch_count += 1
+        end
+      end
+
+      return if field_state.fully_processed?
+    end
+  end
+
+  def reupload(record, field_state)
     # TODO
   end
 
   def load_models_from_registry
     Rails.application.eager_load!
-    Tessa.model_registry
+
+    # Load all Tessa models that can have attachments (not form objects)
+    models = Tessa.model_registry
+      .select { |m| m.respond_to?(:has_one_attached) }
+
+    # Initialize our Record Keeping object
+    ProcessingState.initialize_from_models(models)
+  end
+
+  ProcessingState = Struct.new(:model_queue, :batch_count) do
+    def self.initialize_from_models(models)
+      new(
+        models.map do |model|
+          ModelProcessingState.initialize_from_model(model)
+        end,
+        0
+      )
+    end
+
+    def next_model
+      model_queue.first { |i| !i.fully_processed? }
+    end
+
+    def fully_processed?
+      model_queue.all?(&:fully_processed?)
+    end
+  end
+
+  ModelProcessingState = Struct.new(:class_name, :field_queue) do
+    def self.initialize_from_model(model)
+      new(
+        model.name,
+        model.tessa_fields.map do |name, _|
+          FieldProcessingState.initialize_from_model(model, name)
+        end
+      )
+    end
+
+    def next_field
+      field_queue.first { |i| !i.fully_processed? }
+    end
+
+    def model
+      @model ||= class_name.constantize
+    end
+
+    def fully_processed?
+      field_queue.all?(&:fully_processed?)
+    end
+  end
+
+  FieldProcessingState = Struct.new(:class_name, :field_name, :offset, :success_count, :failed_ids) do
+    def self.initialize_from_model(model, field_name)
+      new(
+        model.name,
+        field_name,
+        0,
+        0,
+        []
+      )
+    end
+
+    def model
+      @model ||= class_name.constantize
+    end
+
+    def field
+      model.tessa_fields[field_name]
+    end
+
+    def query
+      model.where.not(Hash[field.id_field, nil])
+    end
+
+    def count
+      query.count
+    end
+
+    def fully_processed?
+      offset >= count
+    end
   end
 end

--- a/lib/tessa/jobs/migrate_assets_job.rb
+++ b/lib/tessa/jobs/migrate_assets_job.rb
@@ -2,6 +2,8 @@ require 'open-uri'
 
 class Tessa::MigrateAssetsJob < ActiveJob::Base
 
+  queue_as :low
+
   def perform(*args)
     options = args&.extract_options!
     options = {

--- a/lib/tessa/model.rb
+++ b/lib/tessa/model.rb
@@ -10,6 +10,8 @@ module Tessa
       base.extend ClassMethods
       base.after_commit :apply_tessa_change_sets if base.respond_to?(:after_commit)
       base.before_destroy :remove_all_tessa_assets if base.respond_to?(:before_destroy)
+
+      Tessa.model_registry << base
     end
 
     module InstanceMethods

--- a/lib/tessa/model/dynamic_extensions.rb
+++ b/lib/tessa/model/dynamic_extensions.rb
@@ -62,7 +62,8 @@ class Tessa::DynamicExtensions
 
           def attributes
             super.merge({
-              '#{field.id_field}' => #{field.id_field}
+              '#{field.id_field}' => #{field.id_field},
+              '_tessa_#{field.id_field}' => super['#{field.id_field}']
             })
           end
         CODE
@@ -115,14 +116,17 @@ class Tessa::DynamicExtensions
               end
             when nil
               a.detach
+              self.#{field.id_field} = nil
             else
               a.attach(*attachables)
+              self.#{field.id_field} = nil
             end
           end
 
           def attributes
             super.merge({
-              '#{field.id_field}' => #{field.id_field}
+              '#{field.id_field}' => #{field.id_field},
+              '_tessa_#{field.id_field}' => super['#{field.id_field}']
             })
           end
         CODE

--- a/lib/tessa/model/dynamic_extensions.rb
+++ b/lib/tessa/model/dynamic_extensions.rb
@@ -105,7 +105,7 @@ class Tessa::DynamicExtensions
                 else
                   ids = self.#{field.id_field}
                   ids.delete(change.id.to_i)
-                  self.#{field.id_field} = ids
+                  self.#{field.id_field} = ids.any? ? ids : nil
                 end
               end
               attachables.changes.select(&:add?).each do |change|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,10 +5,14 @@ require 'spec_helper'
 
 require File.expand_path('dummy/config/environment.rb', __dir__)
 
+require 'rspec/rails'
+
 RSpec.configure do |config|
   ActiveStorage::Current.host = 'https://www.example.com'
   Rails.application.routes.default_url_options = {
     protocol: 'https',
     host: "www.example.com"
   }
+
+  config.use_transactional_fixtures = true
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'webmock/rspec'
 require 'tessa'
 require 'tempfile'
 
@@ -11,6 +12,8 @@ if ENV['SIMPLE_COV'] || ENV['CC_TEST_REPORTER_ID']
 end
 
 RSpec.configure do |config|
+  WebMock.disable_net_connect!
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end

--- a/spec/tessa/config_spec.rb
+++ b/spec/tessa/config_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Tessa::Config do
-  subject(:config) { Tessa::Config.new }
+  let(:cfg) { Tessa::Config.new }
 
   shared_examples_for "defaults to environment variable" do
     around { |ex| swap_environment_var(variable_name, 'from-env') { ex.run } }
@@ -19,63 +19,63 @@ RSpec.describe Tessa::Config do
   describe "#username" do
     it_behaves_like "defaults to environment variable" do
       let(:variable_name) { 'TESSA_USERNAME' }
-      subject(:username) { config.username }
+      subject { cfg.username }
     end
 
     it "behaves like a normal accessor" do
-      config.username = "my-new-value"
-      expect(config.username).to eq("my-new-value")
+      cfg.username = "my-new-value"
+      expect(cfg.username).to eq("my-new-value")
     end
   end
 
   describe "#password" do
     it_behaves_like "defaults to environment variable" do
       let(:variable_name) { 'TESSA_PASSWORD' }
-      subject(:password) { config.password }
+      subject { cfg.password }
     end
 
     it "behaves like a normal accessor" do
-      config.password = "my-new-value"
-      expect(config.password).to eq("my-new-value")
+      cfg.password = "my-new-value"
+      expect(cfg.password).to eq("my-new-value")
     end
   end
 
   describe "#url" do
     it_behaves_like "defaults to environment variable" do
       let(:variable_name) { 'TESSA_URL' }
-      subject(:url) { config.url }
+      subject { cfg.url }
     end
 
     it "behaves like a normal accessor" do
-      config.url = "my-new-value"
-      expect(config.url).to eq("my-new-value")
+      cfg.url = "my-new-value"
+      expect(cfg.url).to eq("my-new-value")
     end
   end
 
   describe "#strategy" do
     it_behaves_like "defaults to environment variable" do
       let(:variable_name) { 'TESSA_STRATEGY' }
-      subject(:strategy) { config.strategy }
+      subject { cfg.strategy }
     end
 
     it "uses the string 'default' when no envvar passed" do
-      expect(config.strategy).to eq("default")
+      expect(cfg.strategy).to eq("default")
     end
 
     it "behaves like a normal accessor" do
-      config.strategy = "my-new-value"
-      expect(config.strategy).to eq("my-new-value")
+      cfg.strategy = "my-new-value"
+      expect(cfg.strategy).to eq("my-new-value")
     end
   end
 
   describe "#connection" do
     it "is a Faraday::Connection" do
-      expect(config.connection).to be_a(Faraday::Connection)
+      expect(cfg.connection).to be_a(Faraday::Connection)
     end
 
-    context "with values configured" do
-      subject(:connection) { config.connection }
-      before { args.each { |k, v| config.send("#{k}=", v) } }
+    context "with values cfgured" do
+      subject { cfg.connection }
+      before { args.each { |k, v| cfg.send("#{k}=", v) } }
       let(:args) {
         {
           url: "http://tessa.test",
@@ -85,28 +85,28 @@ RSpec.describe Tessa::Config do
       }
 
       it "sets faraday's url prefix to our url" do
-        expect(connection.url_prefix.to_s).to match(config.url)
+        expect(subject.url_prefix.to_s).to match(cfg.url)
       end
 
       context "with faraday spy" do
         let(:spy) { instance_spy(Faraday::Connection) }
         before do
           expect(Faraday).to receive(:new).and_yield(spy)
-          connection
+          subject
         end
 
         it "sets up url_encoded request handler" do
           expect(spy).to have_received(:request).with(:url_encoded)
         end
 
-        it "configures the default adapter" do
+        it "cfgures the default adapter" do
           expect(spy).to have_received(:adapter).with(:net_http)
         end
       end
     end
 
     it "caches the result" do
-      expect(config.connection.object_id).to eq(config.connection.object_id)
+      expect(cfg.connection.object_id).to eq(cfg.connection.object_id)
     end
   end
 end

--- a/spec/tessa/jobs/migrate_assets_job_spec.rb
+++ b/spec/tessa/jobs/migrate_assets_job_spec.rb
@@ -198,9 +198,6 @@ RSpec.describe Tessa::MigrateAssetsJob do
     expect(final_state.fully_processed?).to be false
     field_state = final_state.next_model.next_field
     expect(field_state.offset).to eq(5)
-    expect(field_state.failed_ids).to eq(
-      [2, 4, 6, 8, 10]
-    )
   end
 
   it 'Resumes from marshalled state' do
@@ -218,7 +215,6 @@ RSpec.describe Tessa::MigrateAssetsJob do
       if i % 2 == 0
         # This one failed
         SingleAssetModel.create!(avatar_id: i).tap do |r|
-          field_state.failed_ids << r.id
           field_state.offset += 1
         end
       else

--- a/spec/tessa/jobs/migrate_assets_job_spec.rb
+++ b/spec/tessa/jobs/migrate_assets_job_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+require 'tessa/jobs/migrate_assets_job'
+
+RSpec.describe Tessa::MigrateAssetsJob do
+  it 'does nothing if no db rows' do
+    
+    expect {
+      subject.perform
+    }.to_not change { ActiveStorage::Attachment.count }
+  end
+
+  it 'creates attachments for old tessa assets' do
+    allow(Tessa::Asset).to receive(:find)
+      .with([1, 2])
+      .and_return([
+        Tessa::Asset.new(id: 1,
+          meta: { name: 'README.md' },
+          private_download_url: 'https://test.com/README.md'),
+        Tessa::Asset.new(id: 2,
+          meta: { name: 'LICENSE.txt' },
+          private_download_url: 'https://test.com/LICENSE.txt'),
+      ])
+
+    stub_request(:get, 'https://test.com/README.md')
+      .to_return(body: File.new('README.md'))
+    stub_request(:get, 'https://test.com/LICENSE.txt')
+      .to_return(body: File.new('LICENSE.txt'))
+
+      # DB models with those
+    models = [
+      SingleAssetModel.create!(avatar_id: 1),
+      SingleAssetModel.create!(avatar_id: 2)
+    ]
+
+    expect {
+      subject.perform
+    }.to change { ActiveStorage::Attachment.count }.by(2)
+
+    models.each do |m|
+      expect(m.reload.avatar_id).to eq(nil)
+      # Now it's in activestorage
+      expect(m.avatar.public_url).to start_with(
+        'https://www.example.com/rails/active_storage/blobs/')
+    end
+  end
+end

--- a/spec/tessa/jobs/migrate_assets_job_spec.rb
+++ b/spec/tessa/jobs/migrate_assets_job_spec.rb
@@ -52,4 +52,55 @@ RSpec.describe Tessa::MigrateAssetsJob do
     expect(SingleAssetModel.where.not('avatar_id' => nil).count)
       .to eq(0)
   end
+
+  it 'preserves ActiveStorage blobs' do
+    allow(Tessa::Asset).to receive(:find)
+      .with([1, 2])
+      .and_return([
+        Tessa::Asset.new(id: 1,
+          meta: { name: 'README.md' },
+          private_download_url: 'https://test.com/README.md'),
+        Tessa::Asset.new(id: 2,
+          meta: { name: 'LICENSE.txt' },
+          private_download_url: 'https://test.com/LICENSE.txt'),
+      ])
+    stub_request(:get, 'https://test.com/README.md')
+      .to_return(body: File.new('README.md'))
+    stub_request(:get, 'https://test.com/LICENSE.txt')
+      .to_return(body: File.new('LICENSE.txt'))
+
+    file2 = Rack::Test::UploadedFile.new("LICENSE.txt")
+
+    model = MultipleAssetModel.create!(
+      # The Tessa DB column has the one asset
+      another_place: [1, 2]
+    )
+    # But has already attached a second ActiveStorage blob
+    ::ActiveStorage::Attached::Many.new("multiple_field", model, dependent: :purge_later)
+      .attach(file2)
+    model.save!
+    attachment = model.multiple_field_attachments.first
+
+    expect {
+      subject.perform
+    }.to change { ActiveStorage::Attachment.count }.by(2)
+
+    model = model.reload
+    # The IDs are now the keys of ActiveStorage objects
+    expect(model.another_place).to eq(
+      model.multiple_field.map(&:key))
+    # preserves the existing attachment
+    expect(model.multiple_field_attachments).to include(attachment)
+    expect(model.another_place).to include(attachment.key)
+
+    # all assets are in activestorage
+    model.multiple_field.each do |blob|
+      expect(blob.public_url).to start_with(
+        'https://www.example.com/rails/active_storage/blobs/')
+    end
+
+    # DB column is reset to nil
+    expect(MultipleAssetModel.where.not('another_place' => nil).count)
+      .to eq(0)
+  end
 end


### PR DESCRIPTION
Creates a Migration job and a rake task that kicks it off.

The migration job is done in batches, because changing our data too quickly can overwhelm the apps.  For example, in testing locally, just updating the first 10 "Area" records triggered over 1500 AMQP notification jobs.

refs https://github.com/watermarkchurch/events/issues/460