### PR TITLE
16 remove client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,5 @@ end
 group :test do
   gem 'rspec-rails'
   gem 'webmock'
+  gem 'faraday'
 end

--- a/lib/tasks/tessa.rake
+++ b/lib/tasks/tessa.rake
@@ -4,4 +4,13 @@ namespace :tessa do
   task :migrate => :environment do
     Tessa::MigrateAssetsJob.perform_later
   end
+
+  desc "Verifies that the migration has completed"
+  task :verify => :environment do
+    unless Tessa::MigrateAssetsJob.complete?
+      state = Tessa::MigrateAssetsJob::ProcessingState.initialize_from_models
+
+      raise StandardError, "Tessa::MigrateAssetsJob not yet complete!  #{state.count} records remain to be migrated."
+    end
+  end
 end

--- a/lib/tasks/tessa.rake
+++ b/lib/tasks/tessa.rake
@@ -10,7 +10,7 @@ namespace :tessa do
     unless Tessa::MigrateAssetsJob.complete?
       state = Tessa::MigrateAssetsJob::ProcessingState.initialize_from_models
 
-      raise StandardError, "Tessa::MigrateAssetsJob not yet complete!  #{state.count} records remain to be migrated."
+      abort "Tessa::MigrateAssetsJob not yet complete!  #{state.count} records remain to be migrated."
     end
   end
 end

--- a/lib/tasks/tessa.rake
+++ b/lib/tasks/tessa.rake
@@ -2,7 +2,8 @@
 namespace :tessa do
   desc "Begins the migration of all Tessa assets to ActiveStorage."
   task :migrate => :environment do
-    Tessa::MigrateAssetsJob.perform_later
+    abort "Tessa::MigrateAssetsJob can no longer be performed because the Tessa connection was removed. "\
+      "Please downgrade to tessa ~>1.0 and try again."
   end
 
   desc "Verifies that the migration has completed"
@@ -10,7 +11,8 @@ namespace :tessa do
     unless Tessa::MigrateAssetsJob.complete?
       state = Tessa::MigrateAssetsJob::ProcessingState.initialize_from_models
 
-      abort "Tessa::MigrateAssetsJob not yet complete!  #{state.count} records remain to be migrated."
+      abort "Tessa::MigrateAssetsJob not yet complete!  #{state.count} records remain to be migrated. "\
+        "Please downgrade to tessa ~>1.0 and try again."
     end
   end
 end

--- a/lib/tessa.rb
+++ b/lib/tessa.rb
@@ -1,9 +1,9 @@
 require "tessa/version"
 
-require "faraday"
 require "virtus"
 require "json"
 
+require "tessa/fake_connection"
 require "tessa/config"
 require "tessa/response_factory"
 require "tessa/asset"

--- a/lib/tessa/config.rb
+++ b/lib/tessa/config.rb
@@ -10,15 +10,7 @@ module Tessa
     attribute :strategy, String, default: -> (*_) { ENV['TESSA_STRATEGY'] || DEFAULT_STRATEGY }
 
     def connection
-      @connection ||= Faraday.new(url: url) do |conn|
-        if conn.respond_to?(:basic_auth)
-          conn.basic_auth username, password
-        else # Faraday >= 1.0
-          conn.request :authorization, :basic, username, password
-        end
-        conn.request :url_encoded
-        conn.adapter Faraday.default_adapter
-      end
+      @connection ||= Tessa::FakeConnection.new
     end
   end
 end

--- a/lib/tessa/fake_connection.rb
+++ b/lib/tessa/fake_connection.rb
@@ -5,6 +5,9 @@ module Tessa
 
     [:get, :head, :put, :post, :patch, :delete].each do |method|
       define_method(method) do |*args|
+        if defined?(Bugsnag)
+          Bugsnag.notify("Tessa::FakeConnection##{method} invoked")
+        end
         Tessa::FakeConnection::Response.new()
       end
     end

--- a/lib/tessa/fake_connection.rb
+++ b/lib/tessa/fake_connection.rb
@@ -1,0 +1,26 @@
+module Tessa
+  # Since we no longer connect to the Tessa service, fake out the Tessa connection
+  # so that it always returns 503
+  class FakeConnection
+
+    [:get, :head, :put, :post, :patch, :delete].each do |method|
+      define_method(method) do |*args|
+        Tessa::FakeConnection::Response.new()
+      end
+    end
+
+    class Response
+      def success?
+        false
+      end
+
+      def status
+        503
+      end
+
+      def body
+        '{ "error": "The Tessa connection is no longer implemented." }'
+      end
+    end
+  end
+end

--- a/lib/tessa/jobs/migrate_assets_job.rb
+++ b/lib/tessa/jobs/migrate_assets_job.rb
@@ -127,8 +127,6 @@ class Tessa::MigrateAssetsJob < ActiveJob::Base
   end
 
   def load_models_from_registry
-    Rails.application.eager_load!
-
     # Initialize our Record Keeping object
     ProcessingState.initialize_from_models
   end
@@ -143,6 +141,7 @@ class Tessa::MigrateAssetsJob < ActiveJob::Base
     def self.initialize_from_models(models = nil)
       unless models
         # Load all Tessa models that can have attachments (not form objects)
+        Rails.application.eager_load!
         models = Tessa.model_registry.select { |m| m.respond_to?(:has_one_attached) }
       end
 

--- a/lib/tessa/model.rb
+++ b/lib/tessa/model.rb
@@ -14,6 +14,30 @@ module Tessa
 
     module InstanceMethods
 
+      def pending_tessa_change_sets
+        @pending_tessa_change_sets ||= Hash.new { AssetChangeSet.new }
+      end
+
+      def apply_tessa_change_sets
+        # Pretend like the application was successful but we didn't do anything
+        # because everything is in ActiveStorage now
+        pending_tessa_change_sets.clear
+      end
+
+      def remove_all_tessa_assets
+        self.class.tessa_fields.each do |name, field|
+          change_set = pending_tessa_change_sets[name]
+          field.ids(on: self).each do |asset_id|
+            change_set.remove(asset_id)
+          end
+          pending_tessa_change_sets[name] = change_set
+        end
+      end
+
+      def fetch_tessa_remote_assets(ids)
+        # This should just always return Tessa::AssetFailure
+        Tessa.find_assets(ids)
+      end
     end
 
     module ClassMethods

--- a/lib/tessa/upload/uploads_file.rb
+++ b/lib/tessa/upload/uploads_file.rb
@@ -13,8 +13,6 @@ class Tessa::Upload::UploadsFile
   end
 
   def self.connection_factory
-    Faraday.new do |conn|
-      conn.adapter Faraday.default_adapter
-    end
+    Tessa::FakeConnection.new
   end
 end

--- a/spec/support/remote_call_macro.rb
+++ b/spec/support/remote_call_macro.rb
@@ -24,16 +24,11 @@ RSpec.shared_examples_for "remote call macro" do |method, path, return_type|
   end
 
   context "when response is not successful" do
-    let(:faraday_stubs) {
-      Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.send(method, path) { |env| [422, {}, { "error" => "error" }.to_json] }
-      end
-    }
+    let(:connection) { Tessa::FakeConnection.new }
 
     it "raises Tessa::RequestFailed" do
       expect{ call }.to raise_error { |error|
         expect(error).to be_a(Tessa::RequestFailed)
-        expect(error.response).to be_a(Faraday::Response)
       }
     end
   end

--- a/spec/tessa/config_spec.rb
+++ b/spec/tessa/config_spec.rb
@@ -67,46 +67,4 @@ RSpec.describe Tessa::Config do
       expect(cfg.strategy).to eq("my-new-value")
     end
   end
-
-  describe "#connection" do
-    it "is a Faraday::Connection" do
-      expect(cfg.connection).to be_a(Faraday::Connection)
-    end
-
-    context "with values cfgured" do
-      subject { cfg.connection }
-      before { args.each { |k, v| cfg.send("#{k}=", v) } }
-      let(:args) {
-        {
-          url: "http://tessa.test",
-          username: "username",
-          password: "password",
-        }
-      }
-
-      it "sets faraday's url prefix to our url" do
-        expect(subject.url_prefix.to_s).to match(cfg.url)
-      end
-
-      context "with faraday spy" do
-        let(:spy) { instance_spy(Faraday::Connection) }
-        before do
-          expect(Faraday).to receive(:new).and_yield(spy)
-          subject
-        end
-
-        it "sets up url_encoded request handler" do
-          expect(spy).to have_received(:request).with(:url_encoded)
-        end
-
-        it "cfgures the default adapter" do
-          expect(spy).to have_received(:adapter).with(:net_http)
-        end
-      end
-    end
-
-    it "caches the result" do
-      expect(cfg.connection.object_id).to eq(cfg.connection.object_id)
-    end
-  end
 end

--- a/spec/tessa_spec.rb
+++ b/spec/tessa_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Tessa do
+
+  describe '#find_assets' do
+    it 'returns AssetFailure for singular asset' do
+      result = Tessa.find_assets(1)
+
+      expect(result).to be_a(Tessa::Asset::Failure)
+      expect(result.message).to eq("The service is unavailable at this time.")
+    end
+
+    it 'returns AssetFailure array for multiple assets' do
+      result = Tessa.find_assets([1, 2, 3])
+
+      expect(result.count).to eq(3)
+      result.each do |r|
+        expect(r).to be_a(Tessa::Asset::Failure)
+        expect(r.message).to eq("The service is unavailable at this time.")
+      end
+    end
+  end
+end

--- a/tessa.gemspec
+++ b/tessa.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday"
   spec.add_dependency "virtus", "~>1.0.4"
 
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
* Changes the "Asset" helper method to no longer fall back to looking up data from Tessa.  If it's not in ActiveStorage, it doesn't exist.
* Preserves other deprecated methods, but changes them to no-op with a simulated 503 service unavailable.  This should result in `Tessa::Asset::Failure` being returned any other places where an app directly calls Tessa.

This will be a major version bump.

fixes #16