### PR TITLE
ActiveStorage asset params bug

### DIFF
--- a/lib/tessa/simple_form/asset_input.rb
+++ b/lib/tessa/simple_form/asset_input.rb
@@ -25,11 +25,11 @@ module Tessa
 
       if asset&.key.present?
         return @builder.hidden_field("#{attribute_name}", {
-          value: asset.key,
+          value: asset.signed_id,
           data: {
             meta: meta_for_blob(asset).merge({
               # this allows us to find the hidden HTML input to remove it if we remove the asset
-              "signedID" => asset.key,
+              "signedID" => asset.signed_id,
             })
           }
         })


### PR DESCRIPTION
After the rails 6 upgrade for events, we were accidentally sending the blob key through the form params instead of the signed_id. This threw an `ActiveSupport::MessageVerifier::InvalidSignature` error. Now we're sending the `signed_id` through which is correct.